### PR TITLE
chore: add autofix linting action

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -1,0 +1,17 @@
+name: autofix.ci
+on:
+  pull_request:
+  push:
+    branches: [main]
+permissions:
+  contents: read
+jobs:
+  autofix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          cache: npm
+      - run: npm run lint
+      - uses: autofix-ci/action@551dded8c6cc8a1054039c8bc0b8b48c51dfc6ef


### PR DESCRIPTION
I added the [autofix.ci](https://autofix.ci/) action which automatically lints the code in PRs and pushes to main.

Before merging, we have to think about how well this plays together with the `ct.yml` because currently the auto commit action of the translations fails if newer commits have happened than in the action.