### PR TITLE
chore: add `pull_request_target` trigger, so that forks PRs have access to secret GITHUB_TOKEN

### DIFF
--- a/.github/workflows/genai-pull-request-descriptor.yml
+++ b/.github/workflows/genai-pull-request-descriptor.yml
@@ -1,6 +1,7 @@
 name: GenAI Pull Request Descriptor
 on:
     pull_request:
+    pull_request_target:
 permissions:
     contents: read
     pull-requests: write


### PR DESCRIPTION
> Adding the `pull_request_target` trigger gives the workflow permission to read the read/write `GITHUB_TOKEN`.

However, in this case I think it is safe to use so the GenAI can describe even my PRs that come from a fork.
Or am I just allowed to push new branches to this repo? 🤔 