### PR TITLE
feat: add missing Starlight frontmatter fields

### DIFF
--- a/genaisrc/translator.genai.mts
+++ b/genaisrc/translator.genai.mts
@@ -103,6 +103,11 @@ const FRONTMATTER_FIELDS = [
   "caption",
   "text",
   "tagline",
+  "content",
+  "label",
+  "prev",
+  "next",
+  "badge",
   "og_title",
   "og_description",
 ];


### PR DESCRIPTION
I think since we filter the type of the field to be a `string` it should work because some fields can be different types if you look in [Starlight Frontmatter Reference](https://starlight.astro.build/reference/frontmatter/).

Examples:
- `prev` / `next` can also be boolean or even a more complex type
- `starlight.badge` can also be more complex not just string

`label` is also little bit special because it is used a lot in the frontmatter of Starlight, eg inside `sidebar`, `prev` and `next`

- Closes #54