### PR TITLE
fix: make openai_api_key/openai_api_base and azure_* inputs work

### DIFF
--- a/genaisrc/translator.genai.mts
+++ b/genaisrc/translator.genai.mts
@@ -158,6 +158,13 @@ const isUri = (str: string): URL => {
 };
 
 export default async function main() {
+  // GitHub Action inputs are INPUT_*-prefixed; providers read unprefixed env vars (OPENAI_*, AZURE_*, ...).
+  for (const [key, value] of Object.entries(process.env)) {
+    if (key.startsWith("INPUT_") && value !== undefined) {
+      const name = key.slice("INPUT_".length)
+      if (name && process.env[name] === undefined) process.env[name] = value
+    }
+  }
   const { output, vars } = env;
   const dbg = host.logger(`ct`);
   const dbgn = host.logger(`ct:node`);


### PR DESCRIPTION
## Problem

The action declares and documents `openai_api_key`, `openai_api_base`,
`azure_openai_*` and `azure_ai_inference_*` as `with:` inputs, but passing
them that way has no effect.

GitHub injects a Docker action's `with:` inputs as `INPUT_*` environment
variables. GenAIScript's LLM providers read **unprefixed** env vars
(`OPENAI_API_KEY`/`OPENAI_API_BASE`, `AZURE_*`, ...) — see
`parseTokenFromEnv` in `@genaiscript/core`. The only `INPUT_*` vars
GenAIScript consumes are `INPUT_FILES`, `INPUT_DEBUG`, `INPUT_MODEL*` and
`INPUT_GITHUB_TOKEN`; provider credentials are not among them.

So the documented configuration silently doesn't work, and users are
forced to pass credentials via `env:` instead.

## Fix

In `genaisrc/translator.genai.mts`, at the top of `main()`, strip the
`INPUT_` prefix from every `INPUT_*` env var and export it unprefixed
(unless the unprefixed var already exists). This runs before any LLM
call, so provider resolution picks the credentials up.

## Compatibility

- `with:` inputs now work as documented.
- Existing `env:`-based configs are unaffected (unprefixed env vars win).
- No other behavior changes.